### PR TITLE
fix: pin version of appwrite sdk to ensure demo works

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.7",
-    "react-native-appwrite": "^0.7.0",
+    "react-native-appwrite": "0.7.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-heroicons": "^4.0.0",
     "react-native-reanimated": "~3.16.1",


### PR DESCRIPTION
Hey Adrian, I was following your tutorial and for some reason the version 0.7.1 of the `react-native-appwrite` package is a bit  broken ([reference](https://github.com/appwrite/sdk-for-react-native/issues/49)), and the only fix seems to be reverting to 0.7.0.

Basically, with 0.7.1, the call:

```
    const result = await database.listDocuments(DATABASE_ID, COLLECTION_ID, [
      Query.equal("searchTerm", [query]),
    ]);
```

fails with `Error updating search count: AppwriteException: Already read` (which funnily enough has zero documentation 😩)

Good tutorial btw, helping me de-rust from my brain wheels 👍

---

you'd probably have to do a local `npm install` to update the various locks... but this one is mostly here as reference. You might want to add a pinned comment [over on YT](https://www.youtube.com/watch?v=f8Z9JyB2EIE) maybe 