### PR TITLE
Fix tintColor code

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -11,7 +11,7 @@ function TabIcon({ focused, icon, title }: any) {
         source={images.highlight}
         className="flex flex-row w-full flex-1 min-w-[112px] min-h-14 mt-4 justify-center items-center rounded-full overflow-hidden"
       >
-        <Image source={icon} tintColor="#151312" className="size-5" />
+        <Image source={icon} tintColor={"#151312"} className="size-5" />
         <Text className="text-secondary text-base font-semibold ml-2">
           {title}
         </Text>
@@ -21,7 +21,7 @@ function TabIcon({ focused, icon, title }: any) {
 
   return (
     <View className="size-full justify-center items-center mt-4 rounded-full">
-      <Image source={icon} tintColor="#A8B5DB" className="size-5" />
+      <Image source={icon} tintColor={"#A8B5DB"} className="size-5" />
     </View>
   );
 }


### PR DESCRIPTION
For using tintColor you have to write color name in curly braces otherwise it won't work. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved consistency in color value formatting for tab icons. No visible changes to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->